### PR TITLE
feat: add mancala web app with AI

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Redirecting...</title>
+  <script>
+    const base = '/mancala-2/';
+    const path = location.pathname.replace(base, '');
+    location.replace(base + '#' + path);
+  </script>
+</head>
+<body></body>
+</html>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# mancala-game
+# Mancala 2
+
+Static web app for playing Mancala (Kalah) with multiple AI levels. Built with Vite, React and TypeScript. Works on GitHub Pages under `/mancala-2/`.
+
+## Development
+
+```bash
+npm ci
+npm run dev
+```
+
+## Tests
+
+```bash
+npm test
+npm run test:ui
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## License
+
+MIT

--- a/__tests__/ai.spec.ts
+++ b/__tests__/ai.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { initialState } from '../src/game/rules';
+import { bestMove } from '../src/game/ai/search';
+
+describe('ai', () => {
+  it('uses opening book on start', async () => {
+    const state = initialState();
+    const { move } = await bestMove(state, 'medium');
+    expect(move).toBe(2);
+  });
+});

--- a/__tests__/captures.spec.ts
+++ b/__tests__/captures.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { GameState, applyMove, storeIndex } from '../src/game/rules';
+
+describe('capture', () => {
+  it('captures opposite stones', () => {
+    const state: GameState = {
+      board: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0],
+      player: 0
+    };
+    const res = applyMove(state, 2); // last stone lands in empty pit index2
+    expect(res.captured).toBe(true);
+    expect(res.state.board[storeIndex(0)]).toBe(6);
+  });
+});

--- a/__tests__/endgame.spec.ts
+++ b/__tests__/endgame.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { GameState } from '../src/game/rules';
+import { solveEndgame, totalStones } from '../src/game/ai/endgame';
+import { TranspositionTable } from '../src/game/ai/tt';
+
+describe('endgame solver', () => {
+  it('solves tiny positions', () => {
+    const state: GameState = {
+      board: [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0],
+      player: 0
+    };
+    expect(totalStones(state)).toBe(2);
+    const score = solveEndgame(state, 0, new TranspositionTable());
+    expect(score).toBe(0);
+  });
+});

--- a/__tests__/rules.spec.ts
+++ b/__tests__/rules.spec.ts
@@ -1,0 +1,21 @@
+import { initialState, applyMove, GameState, storeIndex, sidePitsIndices, isTerminal, sweepScore } from '../src/game/rules';
+import { describe, it, expect } from 'vitest';
+
+describe('rules', () => {
+  it('extra turn when ending in store', () => {
+    const state = initialState();
+    const res = applyMove(state, 2); // pit with 4 -> lands in store
+    expect(res.extraTurn).toBe(true);
+  });
+
+  it('terminal sweep', () => {
+    const state: GameState = {
+      board: [0, 0, 0, 0, 1, 0, 20, 0, 0, 0, 0, 0, 1, 10],
+      player: 0
+    };
+    const res = applyMove(state, 4);
+    expect(isTerminal(res.state)).toBe(true);
+    const board = sweepScore(res.state);
+    expect(board[storeIndex(0)] + board[storeIndex(1)]).toBe(22);
+  });
+});

--- a/e2e/basic.spec.ts
+++ b/e2e/basic.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('play one move', async ({ page }) => {
+  await page.goto('http://localhost:4173/');
+  await page.click('text=New');
+  const firstPit = page.locator('div[role=button]').first();
+  await firstPit.click();
+  await expect(page.locator('body')).toContainText('Player');
+});

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,7 @@
+{
+  "new": "New",
+  "undo": "Undo",
+  "redo": "Redo",
+  "settings": "Settings",
+  "copyLink": "Copy Link"
+}

--- a/index.html
+++ b/index.html
@@ -1,8 +1,14 @@
-<!doctype html>
-<html>
-  <head><meta charset="utf-8"><title>Mancala — setup</title></head>
-  <body style="font-family:system-ui;margin:2rem">
-    <h1>Mancala — deployment wiring OK</h1>
-    <p>If you see this, GitHub Pages is working. Stage 2 will replace this with the full app.</p>
-  </body>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="${import.meta.env.BASE_URL}favicon.svg" />
+  <link rel="manifest" href="${import.meta.env.BASE_URL}manifest.webmanifest" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mancala</title>
+</head>
+<body class="min-h-screen bg-gray-100 text-gray-900">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "mancala-2",
+  "version": "1.0.0",
+  "description": "Static Mancala game with strong AI",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:ui": "playwright test",
+    "format": "prettier -w ."
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0",
+    "vite-plugin-pwa": "^0.17.4",
+    "vitest": "^0.34.6",
+    "@playwright/test": "^1.39.0"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="45" fill="#4f46e5" />
+  <text x="50" y="55" font-size="50" text-anchor="middle" fill="white">M</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,8 @@
+{
+  "name": "Mancala",
+  "short_name": "Mancala",
+  "start_url": "/mancala-2/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Mancala game with strong AI"
+}

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Allow: /

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useRef, useState } from 'react';
+import Board from './components/Board';
+import Controls from './components/Controls';
+import SettingsDialog, { Settings } from './components/SettingsDialog';
+import StatusBar from './components/StatusBar';
+import ThinkingIndicator from './components/ThinkingIndicator';
+import MoveLog from './components/MoveLog';
+import { Engine } from './game/engine';
+import { GameState, legalMoves } from './game/rules';
+import { encode, decode } from './utils/encode';
+
+const defaultSettings: Settings = {
+  stones: 4,
+  first: 0,
+  level: 'medium',
+  hints: false
+};
+
+const App: React.FC = () => {
+  const [settings, setSettings] = useState<Settings>(defaultSettings);
+  const engineRef = useRef(new Engine(settings.stones));
+  const [state, setState] = useState<GameState>(engineRef.current.state);
+  const [log, setLog] = useState<number[]>([]);
+  const [showSettings, setShowSettings] = useState(false);
+  const [thinking, setThinking] = useState<{ depth: number; nodes: number } | null>(
+    null
+  );
+  const workerRef = useRef<Worker>();
+  const [hints, setHints] = useState<number[]>([]);
+  const pendingHint = useRef(false);
+
+  // setup worker
+  useEffect(() => {
+    workerRef.current = new Worker(new URL('./game/ai/worker.ts', import.meta.url), {
+      type: 'module'
+    });
+    workerRef.current.onmessage = (e) => {
+      const { move, info } = e.data;
+      if (pendingHint.current) {
+        setHints([move]);
+        pendingHint.current = false;
+      } else {
+        setThinking(info);
+        applyMove(move);
+      }
+    };
+    return () => workerRef.current?.terminate();
+  }, []);
+
+  // load from URL hash
+  useEffect(() => {
+    if (location.hash.length > 1) {
+      const decoded = decode(location.hash.slice(1));
+      if (decoded) {
+        engineRef.current.state = decoded;
+        setState(decoded);
+      }
+    }
+  }, []);
+
+  // AI move when needed
+  useEffect(() => {
+    if (settings.level !== 'human' && state.player === 1) {
+      workerRef.current?.postMessage({ type: 'bestMove', state, level: settings.level });
+      setThinking({ depth: 0, nodes: 0 });
+    }
+    if (settings.hints && state.player === 0) {
+      pendingHint.current = true;
+      workerRef.current?.postMessage({ type: 'bestMove', state, level: 'medium' });
+    } else {
+      setHints([]);
+    }
+  }, [state, settings]);
+
+  const applyMove = (pit: number) => {
+    const res = engineRef.current.move(pit);
+    setState(engineRef.current.state);
+    setLog((l) => [...l, pit]);
+    location.hash = encode(engineRef.current.state);
+    if (res.extraTurn || res.sweep) {
+      // immediate next turn
+      if (settings.level !== 'human' && engineRef.current.state.player === 1) {
+        workerRef.current?.postMessage({
+          type: 'bestMove',
+          state: engineRef.current.state,
+          level: settings.level
+        });
+      }
+    }
+  };
+
+  const onPit = (pit: number) => {
+    if (state.player === 0 && legalMoves(state, 0).includes(pit)) {
+      applyMove(pit);
+    }
+  };
+
+  const restart = (s: Settings) => {
+    engineRef.current = new Engine(s.stones);
+    engineRef.current.state.player = s.first;
+    setState(engineRef.current.state);
+    setLog([]);
+    location.hash = '';
+  };
+
+  const onSettingsClose = (s: Settings | null) => {
+    setShowSettings(false);
+    if (s) {
+      setSettings(s);
+      restart(s);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto text-center p-2">
+      <h1 className="text-2xl mb-2">Mancala</h1>
+      <Board state={state} onPit={onPit} hints={hints} />
+      <StatusBar state={state} />
+      <ThinkingIndicator info={thinking} />
+      <Controls
+        onNew={() => restart(settings)}
+        onUndo={() => {
+          engineRef.current.undo();
+          setState(engineRef.current.state);
+        }}
+        onRedo={() => {
+          engineRef.current.redo();
+          setState(engineRef.current.state);
+        }}
+        onSettings={() => setShowSettings(true)}
+        onCopy={() => navigator.clipboard.writeText(location.href)}
+      />
+      <MoveLog log={log} />
+      <SettingsDialog show={showSettings} settings={settings} onClose={onSettingsClose} />
+    </div>
+  );
+};
+
+export default App;

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import Pit from './Pit';
+import Store from './Store';
+import { GameState, sidePitsIndices, legalMoves } from '../game/rules';
+
+interface BoardProps {
+  state: GameState;
+  onPit: (pit: number) => void;
+  hints: number[];
+}
+
+const Board: React.FC<BoardProps> = ({ state, onPit, hints }) => {
+  const legal = legalMoves(state, state.player);
+  const hintSet = new Set(hints);
+  return (
+    <div className="flex items-center justify-center">
+      <Store stones={state.board[13]} player={1} />
+      <div className="mx-4">
+        <div className="flex flex-row-reverse">
+          {sidePitsIndices(1).map((i) => (
+            <Pit
+              key={i}
+              index={i}
+              stones={state.board[i]}
+              onMove={() => onPit(i)}
+              active={state.player === 1 && legal.includes(i)}
+              hint={hintSet.has(i)}
+            />
+          ))}
+        </div>
+        <div className="flex">
+          {sidePitsIndices(0).map((i) => (
+            <Pit
+              key={i}
+              index={i}
+              stones={state.board[i]}
+              onMove={() => onPit(i)}
+              active={state.player === 0 && legal.includes(i)}
+              hint={hintSet.has(i)}
+            />
+          ))}
+        </div>
+      </div>
+      <Store stones={state.board[6]} player={0} />
+    </div>
+  );
+};
+
+export default Board;

--- a/src/components/Controls.tsx
+++ b/src/components/Controls.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface ControlsProps {
+  onNew: () => void;
+  onUndo: () => void;
+  onRedo: () => void;
+  onSettings: () => void;
+  onCopy: () => void;
+}
+
+const Controls: React.FC<ControlsProps> = ({ onNew, onUndo, onRedo, onSettings, onCopy }) => (
+  <div className="space-x-2 my-2">
+    <button className="px-2 py-1 border rounded" onClick={onNew}>New</button>
+    <button className="px-2 py-1 border rounded" onClick={onUndo}>Undo</button>
+    <button className="px-2 py-1 border rounded" onClick={onRedo}>Redo</button>
+    <button className="px-2 py-1 border rounded" onClick={onSettings}>Settings</button>
+    <button className="px-2 py-1 border rounded" onClick={onCopy}>Copy Link</button>
+  </div>
+);
+
+export default Controls;

--- a/src/components/HintBadge.tsx
+++ b/src/components/HintBadge.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const HintBadge: React.FC = () => <span className="text-green-600">★</span>;
+
+export default HintBadge;

--- a/src/components/MoveLog.tsx
+++ b/src/components/MoveLog.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface Props {
+  log: number[];
+}
+
+const MoveLog: React.FC<Props> = ({ log }) => (
+  <ol className="text-sm max-h-40 overflow-y-auto border p-2">
+    {log.map((m, i) => (
+      <li key={i}>{i + 1}: pit {m}</li>
+    ))}
+  </ol>
+);
+
+export default MoveLog;

--- a/src/components/Pit.tsx
+++ b/src/components/Pit.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { pressable } from '../utils/a11y';
+
+interface PitProps {
+  index: number;
+  stones: number;
+  onMove: () => void;
+  active: boolean;
+  hint?: boolean;
+}
+
+const Pit: React.FC<PitProps> = ({ stones, onMove, active, hint }) => (
+  <div
+    className={`w-16 h-16 m-1 rounded-full flex items-center justify-center border-2 text-lg select-none ${
+      active ? 'cursor-pointer bg-amber-200' : 'bg-white'
+    } ${hint ? 'ring-2 ring-green-500' : ''}`}
+    onClick={active ? onMove : undefined}
+    {...(active ? pressable(onMove) : {})}
+  >
+    {stones}
+  </div>
+);
+
+export default Pit;

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { Player } from '../game/rules';
+
+export interface Settings {
+  stones: number;
+  first: Player;
+  level: 'human' | 'easy' | 'medium' | 'impossible';
+  hints: boolean;
+}
+
+interface Props {
+  show: boolean;
+  settings: Settings;
+  onClose: (s: Settings | null) => void;
+}
+
+const SettingsDialog: React.FC<Props> = ({ show, settings, onClose }) => {
+  const [s, setS] = useState(settings);
+  if (!show) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center" role="dialog" aria-modal="true">
+      <div className="bg-white p-4 rounded space-y-2">
+        <div>
+          <label>Stones per pit </label>
+          <input
+            type="number"
+            value={s.stones}
+            min={1}
+            max={10}
+            onChange={(e) => setS({ ...s, stones: parseInt(e.target.value) })}
+            className="border px-1"
+          />
+        </div>
+        <div>
+          <label>First player </label>
+          <select
+            value={s.first}
+            onChange={(e) => setS({ ...s, first: parseInt(e.target.value) as Player })}
+            className="border px-1"
+          >
+            <option value={0}>You</option>
+            <option value={1}>Opponent</option>
+          </select>
+        </div>
+        <div>
+          <label>Difficulty </label>
+          <select
+            value={s.level}
+            onChange={(e) => setS({ ...s, level: e.target.value as any })}
+            className="border px-1"
+          >
+            <option value="human">Local 1v1</option>
+            <option value="easy">Easy</option>
+            <option value="medium">Medium</option>
+            <option value="impossible">Impossible</option>
+          </select>
+        </div>
+        <div>
+          <label>
+            <input
+              type="checkbox"
+              checked={s.hints}
+              onChange={(e) => setS({ ...s, hints: e.target.checked })}
+            />
+            Hints
+          </label>
+        </div>
+        <div className="text-right space-x-2">
+          <button className="px-2 py-1 border rounded" onClick={() => onClose(null)}>
+            Cancel
+          </button>
+          <button className="px-2 py-1 border rounded" onClick={() => onClose(s)}>
+            OK
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsDialog;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { GameState, isTerminal, sweepScore } from '../game/rules';
+
+interface Props {
+  state: GameState;
+}
+
+const StatusBar: React.FC<Props> = ({ state }) => {
+  if (isTerminal(state)) {
+    const board = sweepScore(state);
+    const diff = board[6] - board[13];
+    let msg = 'Draw';
+    if (diff > 0) msg = 'You win';
+    else if (diff < 0) msg = 'Opponent wins';
+    return <div className="my-2">{msg}</div>;
+  }
+  return <div className="my-2">Player {state.player === 0 ? 'You' : 'Opponent'} to move</div>;
+};
+
+export default StatusBar;

--- a/src/components/Store.tsx
+++ b/src/components/Store.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface StoreProps {
+  stones: number;
+  player: 0 | 1;
+}
+
+const Store: React.FC<StoreProps> = ({ stones }) => (
+  <div className="w-16 h-36 m-1 rounded-lg flex items-center justify-center border-2 bg-gray-200 text-xl">
+    {stones}
+  </div>
+);
+
+export default Store;

--- a/src/components/ThinkingIndicator.tsx
+++ b/src/components/ThinkingIndicator.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+interface Props {
+  info: { depth: number; nodes: number } | null;
+}
+
+const ThinkingIndicator: React.FC<Props> = ({ info }) => (
+  <div className="text-sm h-4">
+    {info ? `d${info.depth} • nodes ${info.nodes}` : ''}
+  </div>
+);
+
+export default ThinkingIndicator;

--- a/src/game/ai/endgame.ts
+++ b/src/game/ai/endgame.ts
@@ -1,0 +1,36 @@
+import { GameState, Player, legalMoves, applyMove, isTerminal, sweepScore } from '../rules';
+import { TranspositionTable } from './tt';
+
+const memo = new Map<string, number>();
+
+const key = (state: GameState) => state.board.join(',') + state.player;
+
+export const totalStones = (state: GameState) =>
+  state.board.reduce((s, n) => s + n, 0);
+
+export const solveEndgame = (
+  state: GameState,
+  player: Player,
+  tt: TranspositionTable
+): number | null => {
+  if (totalStones(state) > 12) return null;
+  return solve(state, player, tt);
+};
+
+const solve = (state: GameState, player: Player, tt: TranspositionTable): number => {
+  if (isTerminal(state)) {
+    const board = sweepScore(state);
+    return board[6] - board[13];
+  }
+  const k = key(state);
+  const cached = memo.get(k);
+  if (cached !== undefined) return cached;
+  let best = -Infinity;
+  for (const m of legalMoves(state, state.player)) {
+    const res = applyMove(state, m);
+    const val = -solve(res.state, player, tt);
+    if (val > best) best = val;
+  }
+  memo.set(k, best);
+  return best;
+};

--- a/src/game/ai/eval.ts
+++ b/src/game/ai/eval.ts
@@ -1,0 +1,29 @@
+import { GameState, sidePitsIndices, storeIndex, Player, legalMoves } from '../rules';
+
+export const evaluate = (state: GameState, player: Player): number => {
+  const myStore = state.board[storeIndex(player)];
+  const oppStore = state.board[storeIndex((player ^ 1) as Player)];
+  const myPits = sidePitsIndices(player).reduce((s, i) => s + state.board[i], 0);
+  const oppPits = sidePitsIndices((player ^ 1) as Player).reduce(
+    (s, i) => s + state.board[i],
+    0
+  );
+  const extraTurn = legalMoves(state, player).some((p) =>
+    wouldExtraTurn(state, player, p)
+  );
+  return (
+    (myStore - oppStore) * 2 +
+    (myPits - oppPits) +
+    (extraTurn ? 1 : 0)
+  );
+};
+
+export const wouldExtraTurn = (
+  state: GameState,
+  player: Player,
+  pit: number
+): boolean => {
+  const stones = state.board[pit];
+  const target = (pit + stones) % 14;
+  return target === storeIndex(player);
+};

--- a/src/game/ai/idb.ts
+++ b/src/game/ai/idb.ts
@@ -1,0 +1,33 @@
+// basic IndexedDB helpers for persisting transposition table segments
+const DB_NAME = 'mancala-tt';
+const STORE = 'entries';
+
+const openDb = () =>
+  new Promise<IDBDatabase>((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+
+export const saveTT = async (key: number, value: any) => {
+  const db = await openDb();
+  const tx = db.transaction(STORE, 'readwrite');
+  tx.objectStore(STORE).put(value, key);
+  return new Promise<void>((resolve, reject) => {
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+  });
+};
+
+export const loadTT = async (key: number) => {
+  const db = await openDb();
+  const tx = db.transaction(STORE, 'readonly');
+  const req = tx.objectStore(STORE).get(key);
+  return new Promise<any>((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+};

--- a/src/game/ai/openingBook.ts
+++ b/src/game/ai/openingBook.ts
@@ -1,0 +1,5 @@
+// simple opening book mapping state hash to move
+export const openingBook: Record<string, number> = {
+  // starting position -> pit index for player 0
+  'start': 2
+};

--- a/src/game/ai/ordering.ts
+++ b/src/game/ai/ordering.ts
@@ -1,0 +1,19 @@
+import { GameState, Player, applyMove, legalMoves } from '../rules';
+import { wouldExtraTurn } from './eval';
+
+export const orderMoves = (
+  state: GameState,
+  player: Player,
+  moves: number[]
+): number[] => {
+  return moves
+    .map((m) => {
+      let score = 0;
+      if (wouldExtraTurn(state, player, m)) score += 2;
+      const res = applyMove(state, m);
+      if (res.captured) score += 1;
+      return { m, score };
+    })
+    .sort((a, b) => b.score - a.score)
+    .map((o) => o.m);
+};

--- a/src/game/ai/search.ts
+++ b/src/game/ai/search.ts
@@ -1,0 +1,131 @@
+import { GameState, Player, legalMoves, applyMove, isTerminal, sweepScore } from '../rules';
+import { evaluate } from './eval';
+import { orderMoves } from './ordering';
+import { tt, Flag } from './tt';
+import { hashState } from './zobrist';
+import { openingBook } from './openingBook';
+import { solveEndgame } from './endgame';
+
+export interface SearchInfo {
+  depth: number;
+  nodes: number;
+}
+
+const TIME_LEVEL: Record<string, number> = {
+  easy: 0,
+  medium: 500,
+  impossible: 2500
+};
+
+export const bestMove = async (
+  state: GameState,
+  level: 'easy' | 'medium' | 'impossible'
+): Promise<{ move: number; info: SearchInfo }> => {
+  const moves = legalMoves(state, state.player);
+  if (level === 'easy') {
+    // random with preference
+    const ordered = orderMoves(state, state.player, moves);
+    return {
+      move: ordered[0],
+      info: { depth: 0, nodes: 1 }
+    };
+  }
+
+  const bookKey = openingKey(state);
+  if (openingBook[bookKey] !== undefined) {
+    return { move: openingBook[bookKey], info: { depth: 0, nodes: 0 } };
+  }
+
+  const end = solveEndgame(state, state.player, tt);
+  if (end !== null) {
+    // choose move leading to end result
+    let best = moves[0];
+    let bestScore = -Infinity;
+    for (const m of moves) {
+      const res = applyMove(state, m);
+      const score = -solveEndgame(res.state, state.player, tt)!;
+      if (score > bestScore) {
+        bestScore = score;
+        best = m;
+      }
+    }
+    return { move: best, info: { depth: 0, nodes: moves.length } };
+  }
+
+  let best = moves[0];
+  let depth = 1;
+  const info: SearchInfo = { depth: 0, nodes: 0 };
+  const endTime = Date.now() + TIME_LEVEL[level];
+  while (Date.now() < endTime) {
+    let alpha = -Infinity;
+    let beta = Infinity;
+    let bestScore = -Infinity;
+    info.nodes = 0;
+    for (const move of orderMoves(state, state.player, moves)) {
+      const res = applyMove(state, move);
+      const score = -search(res.state, depth - 1, -beta, -alpha, info);
+      if (score > bestScore) {
+        bestScore = score;
+        best = move;
+      }
+      if (score > alpha) alpha = score;
+    }
+    info.depth = depth;
+    depth++;
+  }
+  return { move: best, info };
+};
+
+const search = (
+  state: GameState,
+  depth: number,
+  alpha: number,
+  beta: number,
+  info: SearchInfo
+): number => {
+  info.nodes++;
+  const key = hashState(state);
+  const ttEntry = tt.get(key);
+  if (ttEntry && ttEntry.depth >= depth) {
+    if (ttEntry.flag === 'exact') return ttEntry.score;
+    if (ttEntry.flag === 'lower' && ttEntry.score > alpha) alpha = ttEntry.score;
+    else if (ttEntry.flag === 'upper' && ttEntry.score < beta) beta = ttEntry.score;
+    if (alpha >= beta) return ttEntry.score;
+  }
+
+  if (depth === 0 || isTerminal(state)) {
+    const board = isTerminal(state) ? sweepScore(state) : state.board;
+    const score = evaluate({ board, player: state.player }, state.player);
+    return score;
+  }
+
+  let best = -Infinity;
+  let flag: Flag = 'upper';
+  for (const move of orderMoves(state, state.player, legalMoves(state, state.player))) {
+    const res = applyMove(state, move);
+    const score = -search(res.state, depth - 1, -beta, -alpha, info);
+    if (score > best) {
+      best = score;
+    }
+    if (score > alpha) {
+      alpha = score;
+      flag = 'exact';
+    }
+    if (alpha >= beta) {
+      flag = 'lower';
+      break;
+    }
+  }
+  tt.set({ key, depth, score: best, flag });
+  return best;
+};
+
+const openingKey = (state: GameState): string => {
+  // starting position detection
+  if (state.board.every((v, i) => {
+    if (i === 6 || i === 13) return v === 0;
+    return v === 4;
+  }))
+    return 'start';
+  return '';
+};

--- a/src/game/ai/tt.ts
+++ b/src/game/ai/tt.ts
@@ -1,0 +1,30 @@
+export type Flag = 'exact' | 'lower' | 'upper';
+
+export interface TTEntry {
+  key: number;
+  depth: number;
+  score: number;
+  flag: Flag;
+  best?: number;
+}
+
+export class TranspositionTable {
+  table = new Map<number, TTEntry>();
+  order: number[] = [];
+  constructor(public max = 100000) {}
+
+  get(key: number) {
+    return this.table.get(key);
+  }
+
+  set(entry: TTEntry) {
+    if (this.table.size >= this.max) {
+      const oldest = this.order.shift();
+      if (oldest !== undefined) this.table.delete(oldest);
+    }
+    this.table.set(entry.key, entry);
+    this.order.push(entry.key);
+  }
+}
+
+export const tt = new TranspositionTable();

--- a/src/game/ai/worker.ts
+++ b/src/game/ai/worker.ts
@@ -1,0 +1,10 @@
+import { bestMove } from './search';
+
+self.onmessage = async (e) => {
+  const { type, state, level } = e.data;
+  if (type === 'bestMove') {
+    const res = await bestMove(state, level);
+    (self as any).postMessage(res);
+  }
+};
+export {}; // TS isolate

--- a/src/game/ai/zobrist.ts
+++ b/src/game/ai/zobrist.ts
@@ -1,0 +1,27 @@
+import { GameState } from '../rules';
+
+const rand = (() => {
+  let x = 0x12345678;
+  return () => {
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    return x >>> 0;
+  };
+})();
+
+export const zobrist: number[][] = Array.from({ length: 14 }, () =>
+  Array.from({ length: 49 }, () => rand())
+);
+
+export const playerKey = rand();
+
+export const hashState = (state: GameState): number => {
+  let h = 0;
+  for (let i = 0; i < 14; i++) {
+    let stones = state.board[i];
+    for (let k = 0; k < stones; k++) h ^= zobrist[i][k];
+  }
+  if (state.player === 1) h ^= playerKey;
+  return h >>> 0;
+};

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -1,0 +1,41 @@
+import { GameState, initialState, applyMove, Player } from './rules';
+
+export class Engine {
+  state: GameState;
+  history: GameState[] = [];
+  future: GameState[] = [];
+
+  constructor(stones = 4) {
+    this.state = initialState(stones);
+  }
+
+  move(pit: number) {
+    const result = applyMove(this.state, pit);
+    this.history.push(this.state);
+    this.state = result.state;
+    this.future = [];
+    return result;
+  }
+
+  undo() {
+    const prev = this.history.pop();
+    if (prev) {
+      this.future.push(this.state);
+      this.state = prev;
+    }
+  }
+
+  redo() {
+    const next = this.future.pop();
+    if (next) {
+      this.history.push(this.state);
+      this.state = next;
+    }
+  }
+
+  reset(stones = 4) {
+    this.history = [];
+    this.future = [];
+    this.state = initialState(stones);
+  }
+}

--- a/src/game/rules.ts
+++ b/src/game/rules.ts
@@ -1,0 +1,93 @@
+export type Player = 0 | 1;
+
+export interface GameState {
+  board: number[]; // length 14
+  player: Player;
+}
+
+export const storeIndex = (player: Player) => (player === 0 ? 6 : 13);
+
+export const sidePitsIndices = (player: Player) =>
+  player === 0 ? [0, 1, 2, 3, 4, 5] : [7, 8, 9, 10, 11, 12];
+
+export const initialState = (stonesPerPit = 4): GameState => {
+  const board = new Array(14).fill(0);
+  for (const i of [...sidePitsIndices(0), ...sidePitsIndices(1)]) {
+    board[i] = stonesPerPit;
+  }
+  return { board, player: 0 };
+};
+
+export const legalMoves = (state: GameState, player: Player) =>
+  sidePitsIndices(player).filter((i) => state.board[i] > 0);
+
+export const isTerminal = (state: GameState) =>
+  sidePitsIndices(0).every((i) => state.board[i] === 0) ||
+  sidePitsIndices(1).every((i) => state.board[i] === 0);
+
+export const sweepScore = (state: GameState) => {
+  const board = state.board.slice();
+  const p0 = sidePitsIndices(0).reduce((s, i) => s + board[i], 0);
+  const p1 = sidePitsIndices(1).reduce((s, i) => s + board[i], 0);
+  for (const i of sidePitsIndices(0)) board[i] = 0;
+  for (const i of sidePitsIndices(1)) board[i] = 0;
+  board[storeIndex(0)] += p0;
+  board[storeIndex(1)] += p1;
+  return board;
+};
+
+export interface MoveResult {
+  state: GameState;
+  extraTurn: boolean;
+  captured: boolean;
+  sweep: boolean;
+}
+
+export const applyMove = (
+  state: GameState,
+  pit: number
+): MoveResult => {
+  const player = state.player;
+  if (!legalMoves(state, player).includes(pit)) {
+    throw new Error('Illegal move');
+  }
+  const board = state.board.slice();
+  let stones = board[pit];
+  board[pit] = 0;
+  let idx = pit;
+  while (stones > 0) {
+    idx = (idx + 1) % 14;
+    if (idx === storeIndex((player ^ 1) as Player)) continue; // skip opponent store
+    board[idx]++;
+    stones--;
+  }
+  let extraTurn = idx === storeIndex(player);
+  let captured = false;
+  if (!extraTurn && sidePitsIndices(player).includes(idx) && board[idx] === 1) {
+    const opposite = 12 - idx;
+    if (board[opposite] > 0) {
+      board[storeIndex(player)] += board[opposite] + 1;
+      board[idx] = 0;
+      board[opposite] = 0;
+      captured = true;
+    }
+  }
+  let sweep = false;
+  if (isTerminal({ board, player })) {
+    const swept = sweepScore({ board, player });
+    swept; // for typing
+    sweep = true;
+    return {
+      state: { board: swept, player },
+      extraTurn,
+      captured,
+      sweep
+    };
+  }
+  return {
+    state: { board, player: extraTurn ? player : ((player ^ 1) as Player) },
+    extraTurn,
+    captured,
+    sweep
+  };
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/utils/a11y.ts
+++ b/src/utils/a11y.ts
@@ -1,0 +1,10 @@
+export const pressable = (action: () => void) => ({
+  onKeyDown: (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      action();
+    }
+  },
+  tabIndex: 0,
+  role: 'button'
+});

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,0 +1,3 @@
+export const assert = (cond: any, msg = 'assert'): asserts cond => {
+  if (!cond) throw new Error(msg);
+};

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -1,0 +1,12 @@
+import { GameState, Player } from '../game/rules';
+
+export const encode = (state: GameState): string =>
+  state.board.join('.') + ':' + state.player;
+
+export const decode = (s: string): GameState | null => {
+  const [b, p] = s.split(':');
+  if (!b || !p) return null;
+  const board = b.split('.').map((n) => parseInt(n));
+  if (board.length !== 14) return null;
+  return { board, player: parseInt(p) as Player };
+};

--- a/src/utils/timing.ts
+++ b/src/utils/timing.ts
@@ -1,0 +1,1 @@
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vite/client", "vitest", "@types/node"]
+  },
+  "include": ["src", "__tests__", "e2e", "vite.config.ts"],
+  "exclude": ["dist"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { VitePWA } from 'vite-plugin-pwa';
+
+export default defineConfig({
+  base: '/mancala-2/',
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      manifest: {
+        name: 'Mancala',
+        short_name: 'Mancala',
+        start_url: '/mancala-2/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        description: 'Mancala game with strong AI',
+        icons: []
+      }
+    })
+  ]
+});


### PR DESCRIPTION
## Summary
- implement Kalah rules engine and undoable game controller
- add iterative deepening AI with transposition table and web worker
- create React UI with settings, hints, and PWA config for GitHub Pages

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@playwright%2ftest)*
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf6022f84832ab7799964ffa30f62